### PR TITLE
Fix typo for type definition of `completed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The plan includes all exports from [`node:assert`](https://nodejs.org/api/assert
 as well as:
 
 * `end()`: a function to complete the plan
-* `complete`: a promise that will resolve when the plan is completed.
+* `completed`: a promise that will resolve when the plan is completed.
 
 ## License
 

--- a/tspl.d.ts
+++ b/tspl.d.ts
@@ -9,7 +9,7 @@ export interface Options {
 }
 
 export type Plan = Omit<typeof assert, 'CallTracker' | 'AssertionError' | 'strict'> & {
-  complete: Promise<void>
+  completed: Promise<void>
   end: () => void
 }
 

--- a/tspl.test-d.ts
+++ b/tspl.test-d.ts
@@ -11,7 +11,7 @@ test('tspl', (t) => {
   expectType<void>(p.end());
 });
 
-test('complete', async (t) => {
+test('completed', async (t) => {
   expectType<Plan>(tspl(t, { plan: 1 }));
   const p: Plan = tspl(t, { plan: 1 });
 
@@ -19,7 +19,7 @@ test('complete', async (t) => {
     p.strictEqual(1, 1);
   });
 
-  await p.complete
+  await p.completed
 });
 
 test('tspl', (t) => {


### PR DESCRIPTION
`complete` -> `completed`