### PR TITLE
Support `await plan`

### DIFF
--- a/test.js
+++ b/test.js
@@ -83,3 +83,13 @@ test('wait', async (t) => {
 
   await completed
 })
+
+test('await plan', async (t) => {
+  const plan = tspl(t, { plan: 1 })
+
+  setImmediate(() => {
+    plan.strictEqual(1, 1)
+  })
+
+  await plan
+})

--- a/tspl.js
+++ b/tspl.js
@@ -8,11 +8,11 @@ function tspl (t, opts = {}) {
   }
 
   let ended = false
-  const { plan } = opts
+  const { plan: expectedPlan } = opts
   let actual = 0
 
   let _resolve
-  const completed = new Promise((resolve) => {
+  const plan = new Promise((resolve) => {
     _resolve = resolve
   })
 
@@ -21,8 +21,8 @@ function tspl (t, opts = {}) {
       return
     }
 
-    if (plan) {
-      assert.strictEqual(actual, plan, 'The plan was not completed')
+    if (expectedPlan) {
+      assert.strictEqual(actual, expectedPlan, 'The plan was not completed')
     } else {
       assert.fail('The plan was not completed')
     }
@@ -34,24 +34,19 @@ function tspl (t, opts = {}) {
     }
     ended = true
 
-    if (plan) {
-      assert.strictEqual(actual, plan, 'The plan was not completed')
+    if (expectedPlan) {
+      assert.strictEqual(actual, expectedPlan, 'The plan was not completed')
       _resolve()
     }
   }
 
-  const res = {
-    completed,
-    end
-  }
-
   for (const method of Object.keys(assert)) {
     if (method.match(/^[a-z]/)) {
-      res[method] = (...args) => {
+      plan[method] = (...args) => {
         actual++
         const res = assert[method](...args)
 
-        if (actual === plan) {
+        if (actual === expectedPlan) {
           _resolve()
         }
 
@@ -60,7 +55,9 @@ function tspl (t, opts = {}) {
     }
   }
 
-  return res
+  plan.end = end
+  plan.completed = plan
+  return plan
 }
 
 module.exports = tspl


### PR DESCRIPTION
I find myself routinely forgetting that I have to `await plan.completed` instead of `await plan`. This PR makes both things work.